### PR TITLE
Cadastro do local e calculo da nota de seguranca #4

### DIFF
--- a/cadastro_local_app.py
+++ b/cadastro_local_app.py
@@ -1,0 +1,44 @@
+from flask import Flask, request, jsonify
+import re
+
+app = Flask(__name__)
+
+locais = []  # Armazenamento temporário para os locais
+
+def validar_endereco(endereco):
+    return isinstance(endereco, str) and len(endereco.strip()) >= 5
+
+def calcular_nota_seguranca(num_incidentes, relatos):
+    nota = 10 - (num_incidentes * 1) - (len(relatos) * 0.5)
+    return max(nota, 0)  # Garante que a nota não seja menor que 0
+
+@app.route('/cadastrar_local', methods=['POST'])
+def cadastrar_local():
+    data = request.get_json()
+
+    # Validações básicas
+    if not data.get('nome'):
+        return jsonify({'erro': 'Nome do local é obrigatório'}), 400
+    if not data.get('endereco') or not validar_endereco(data['endereco']):
+        return jsonify({'erro': 'Endereço inválido'}), 400
+    if not data.get('proximidade'):
+        return jsonify({'erro': 'Proximidade é obrigatória'}), 400
+    if not isinstance(data.get('numero_incidentes'), int) or data['numero_incidentes'] < 0:
+        return jsonify({'erro': 'Número de incidentes deve ser um número inteiro >= 0'}), 400
+    if not isinstance(data.get('relatos'), list):
+        return jsonify({'erro': 'Relatos devem ser enviados como uma lista'}), 400
+
+    nota_seguranca = calcular_nota_seguranca(data['numero_incidentes'], data['relatos'])
+
+    local = {
+        'nome': data['nome'],
+        'endereco': data['endereco'],
+        'proximidade': data['proximidade'],
+        'numero_incidentes': data['numero_incidentes'],
+        'relatos': data['relatos'],
+        'nota_seguranca': nota_seguranca
+    }
+
+    locais.append(local)
+
+    return jsonify({'mensagem': 'Local cadastrado com sucesso!', 'local': local}), 201

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+pytest

--- a/test_cadastro_local.py
+++ b/test_cadastro_local.py
@@ -1,0 +1,124 @@
+from cadastro_local_app import app
+
+def test_cadastro_sucesso():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'nome': 'Bolsão da BC',
+        'endereco': 'R. Sérgio Buarque de Holanda, 421',
+        'proximidade': 'Biblioteca Central da Unicamp',
+        'numero_incidentes': 2,
+        'relatos': [
+            'roubo de biciclate',
+            'assalto a mão armada',
+        ]
+    })
+    assert resposta.status_code == 201
+    assert resposta.get_json()['mensagem'] == 'Local cadastrado com sucesso!'
+
+
+def test_todos_os_campos_vazios():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={})
+    assert resposta.status_code == 400
+    assert 'Nome' in resposta.get_json()['erro']
+
+
+def test_nome_invalido():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'endereco': 'R. Sérgio Buarque de Holanda, 421',
+        'proximidade': 'Biblioteca Central da Unicamp',
+        'numero_incidentes': 2,
+        'relatos': [
+            'roubo de biciclate',
+            'assalto a mão armada',
+        ]
+    })
+    assert resposta.status_code == 400
+    assert 'Nome' in resposta.get_json()['erro']
+
+def test_endereco_invalido():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'nome': 'Bolsão da BC',
+        'endereco': 12,
+        'proximidade': 'Biblioteca Central da Unicamp',
+        'numero_incidentes': 2,
+        'relatos': [
+            'roubo de biciclate',
+            'assalto a mão armada',
+        ]
+    })
+    assert resposta.status_code == 400
+    assert 'Endereço inválido' == resposta.get_json()['erro']
+
+def test_proximidade_invalida():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'nome': 'Bolsão da BC',
+        'endereco': 'R. Sérgio Buarque de Holanda, 421',
+        'numero_incidentes': 2,
+        'relatos': [
+            'roubo de biciclate',
+            'assalto a mão armada',
+        ]
+    })
+    assert resposta.status_code == 400
+    assert 'Proximidade' in resposta.get_json()['erro']
+
+def test_numero_incidentes_invalido():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'nome': 'Bolsão da BC',
+        'endereco': 'R. Sérgio Buarque de Holanda, 421',
+        'proximidade': 'Biblioteca Central da Unicamp',
+        'numero_incidentes': -1,
+        'relatos': [
+            'roubo de biciclate',
+            'assalto a mão armada',
+        ]
+    })
+    assert resposta.status_code == 400
+    assert 'Número de incidentes deve ser um número inteiro >= 0' in resposta.get_json()['erro']
+
+def test_relatos_invalido():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'nome': 'Bolsão da BC',
+        'endereco': 'R. Sérgio Buarque de Holanda, 421',
+        'proximidade': 'Biblioteca Central da Unicamp',
+        'numero_incidentes': 2,
+        'relatos': 'roubo de biciclate'
+    })
+    assert resposta.status_code == 400
+    assert 'Relatos devem ser enviados como uma lista' in resposta.get_json()['erro']
+
+def test_nota_seguranca():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'nome': 'Bolsão da BC',
+        'endereco': 'R. Sérgio Buarque de Holanda, 421',
+        'proximidade': 'Biblioteca Central da Unicamp',
+        'numero_incidentes': 2,
+        'relatos': [
+            'roubo de biciclate',
+            'assalto a mão armada',
+        ]
+    })
+    assert resposta.status_code == 201
+    assert resposta.get_json()['local']['nota_seguranca'] == 7.0
+
+def test_nota_seguranca_zero():
+    cliente = app.test_client()
+    resposta = cliente.post('/cadastrar_local', json={
+        'nome': 'Bolsão da BC',
+        'endereco': 'R. Sérgio Buarque de Holanda, 421',
+        'proximidade': 'Biblioteca Central da Unicamp',
+        'numero_incidentes': 10,
+        'relatos': [
+            'roubo de biciclate',
+            'assalto a mão armada',
+        ]
+    })
+    assert resposta.status_code == 201
+    assert resposta.get_json()['local']['nota_seguranca'] == 0.0


### PR DESCRIPTION
Foi implementada a funcionalidade de **cadastro de local**, atendendo aos requisitos da Issue #4. Essa funcionalidade permite registrar locais com foco em segurança e confiabilidade para os usuários da plataforma.

- Criação do endpoint `/cadastrar_local` com método `POST`
- Validação dos seguintes campos:
  - `nome` (obrigatório)
  - `endereco` (deve ser string válida com mínimo de 5 caracteres)
  - `proximidade` (obrigatório)
  - `numero_incidentes` (deve ser um número inteiro ≥ 0)
  - `relatos` (string)
  - Cálculo automático da nota de segurança do local com base em:
  - `numero_incidentes`: -1 ponto por incidente
  - `relatos`: -0.5 ponto por relato
  - Nota mínima limitada a `0` (escala de 0 a 10)
- Armazenamento temporário dos locais em uma lista `locais[]`
